### PR TITLE
Switch authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,21 +18,28 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
 
   traefik-forward-auth:
-    image: thomseddon/traefik-forward-auth:2
+    image: quay.io/oauth2-proxy/oauth2-proxy:latest
     environment:
-      - http_proxy=${http_proxy}
-      - https_proxy=${https_proxy}
-      - DEFAULT_PROVIDER=oidc
-      - PROVIDERS_OIDC_ISSUER_URL=${OAUTH_ISSUER_URL}
-      - PROVIDERS_OIDC_CLIENT_ID=${OAUTH_CLIENT_ID}
-      - PROVIDERS_OIDC_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
-      - SECRET=${AUTHENTICATION_SECRET}
-      - COOKIE_DOMAIN=${GUI_HOST}
+      - OAUTH2_PROXY_PROVIDER=oidc
+      - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
+      - OAUTH2_PROXY_OIDC_ISSUER_URL=${OAUTH_ISSUER_URL}
+      - OAUTH2_PROXY_CLIENT_ID=${OAUTH_CLIENT_ID}
+      - OAUTH2_PROXY_CLIENT_SECRET=${OAUTH_CLIENT_SECRET}
+      - OAUTH2_PROXY_COOKIE_SECRET=${AUTHENTICATION_SECRET}
+      - OAUTH2_PROXY_COOKIE_DOMAINS=.${GUI_HOST}
+      - OAUTH2_PROXY_HTTP_ADDRESS=:4180
+      - OAUTH2_PROXY_REVERSE_PROXY=true
+      - OAUTH2_PROXY_WHITELIST_DOMAINS=.${GUI_HOST}
+      - OAUTH2_PROXY_UPSTREAMS=static://202
+      - OAUTH2_PROXY_EMAIL_DOMAINS=*
+      - OAUTH2_PROXY_ALLOWED_GROUPS=${ALLOWED_GROUPS}
     labels:
       - "traefik.enable=true"
-      - "traefik.http.middlewares.traefik-forward-auth.forwardauth.address=http://traefik-forward-auth:4181"
+      - "traefik.http.middlewares.traefik-forward-auth.forwardauth.address=http://traefik-forward-auth:4180"
       - "traefik.http.middlewares.traefik-forward-auth.forwardauth.authResponseHeaders=X-Forwarded-User"
-      - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4181"
+      - "traefik.http.services.traefik-forward-auth.loadbalancer.server.port=4180"
+      - "traefik.http.routers.oauth2.rule=Host(`${GUI_HOST}`) && PathPrefix(`/oauth2/`)"
+      - "traefik.http.routers.oauth2.tls=true"
 
   lens:
     # NOTE: This will only host the default image. You will need to create your own image at docker hub using the provided Dockerfile.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
   traefik-forward-auth:
     image: quay.io/oauth2-proxy/oauth2-proxy:latest
     environment:
+      - http_proxy=${http_proxy}
+      - https_proxy=${https_proxy}
       - OAUTH2_PROXY_PROVIDER=oidc
       - OAUTH2_PROXY_SKIP_PROVIDER_BUTTON=true
       - OAUTH2_PROXY_OIDC_ISSUER_URL=${OAUTH_ISSUER_URL}

--- a/example.env
+++ b/example.env
@@ -17,3 +17,5 @@ OAUTH_ISSUER_URL="the-discovery-adress-of-your-oauth-provider"
 OAUTH_CLIENT_ID="your-oauth-client-id"
 OAUTH_CLIENT_SECRET="your-oauth-client-id"
 AUTHENTICATION_SECRET="insert-a-random-passphrase-here"
+
+ALLOWED_GROUPS="group1, group2, group3"


### PR DESCRIPTION
Pull request to switch authentication from https://github.com/thomseddon/traefik-forward-auth to https://github.com/oauth2-proxy/oauth2-proxy (as in https://github.com/samply/dktk-explorer/pull/35/files)

With minor adjustments:

    ALLOWED_GROUPS with comma separation, as recommended in https://oauth2-proxy.github.io/oauth2-proxy/docs/features/endpoints/#auth
    No OAUTH2_PROXY_SCOPE, as we now have a groups scope

